### PR TITLE
fix: lock dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ To run serverless functions locally
 
 ## Deployment
 
-TODO
+The site is deployed to Netlify, under an [open source plan](https://www.netlify.com/open-source/).
+
+Upon push or merge to `develop`, a live **deploy preview** is created via GitHub actions.
+
+Upon push or merge to `master`, the site is built and a production deployment is made automatically via Netlify.
 
 ## Server-side vs client-side rendering of formulas
 
@@ -42,7 +46,7 @@ There are two approaches to rendering LaTeX formulas, which configured in `.env`
 1. Server-side, enabled if `REACT_APP_SVG_RENDERING=server`. Images are rendered by the serverless function [`render-math-svg.js`](./lambda/render-math-svg.js), which converts LaTeX to SVG.
 2. Client-side, enabled if `REACT_APP_SVG_RENDERING=client`. Images are Base64 encoded and the entire application can be hosted as a static website without serverless functions.
 
-### Which approach should I use?
+### Which approach should I use?
 
 Use server-side rendering if there's a need to paste content from the editor to another website e.g. Moodle. Moodle and other tools may not allow Base64 encoded (client-side) images and require images to be returned from a url e.g `<img src="https://editori.example.com/math.svg?latex=xyz">`.
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,36 +5,23 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <!-- TODO: Meta tags -->
     <meta name="description" content="Eiran aikuislukio" />
     <link rel="stylesheet" href="https://use.typekit.net/tmu4qhv.css" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+
     <title>Eira Math Editor</title>
 
-    <!-- Dependencies from the example -->
     <link
       rel="stylesheet"
       type="text/css"
-      href="//unpkg.com/@digabi/mathquill/build/mathquill.css"
+      href="//unpkg.com/@digabi/mathquill@0.10.5/build/mathquill.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="//unpkg.com/rich-text-editor/dist/rich-text-editor.css"
+      href="//unpkg.com/rich-text-editor@6.1.0/dist/rich-text-editor.css"
     />
     <script
       src="//code.jquery.com/jquery-3.4.1.min.js"
@@ -42,7 +29,7 @@
       crossorigin="anonymous"
     ></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/bacon.js/1.0.1/Bacon.min.js"></script>
-    <script src="//unpkg.com/rich-text-editor/dist/rich-text-editor-bundle.js"></script>
+    <script src="//unpkg.com/rich-text-editor@6.0.1/dist/rich-text-editor-bundle.js"></script>
     <script
       type="text/javascript"
       src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js"
@@ -51,15 +38,5 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>


### PR DESCRIPTION
The latest major changes to rich-text-editor caused breaking
changes when pasting images to the editor. Lock the dependency to
the latest known working version.